### PR TITLE
`azurerm_linux_web_app` - updated deprecated command in docs

### DIFF
--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -168,7 +168,7 @@ An `application_stack` block supports the following:
 
 * `java_version` - (Optional) The Version of Java to use. Possible values include `8`, `11`, `17`, and `21`.
 
-~> **NOTE:** The valid version combinations for `java_version`, `java_server` and `java_server_version` can be checked from the command line via `az webapp list-runtimes --linux`.
+~> **NOTE:** The valid version combinations for `java_version`, `java_server` and `java_server_version` can be checked from the command line via `az webapp list-runtimes --os-type linux`.
 
 ~> **NOTE:** `java_server`, `java_server_version`, and `java_version` must all be specified if building a java app
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change
- [X] Documentation 

## Details
The command `az webapp list-runtimes --linux` is now deprecated. When running it, a message appears `Argument 'linux' has been deprecated and will be removed in a future release. Use '--os-type' instead.`

Updated the docs to use the new command `az webapp list-runtimes --os-type linux` which provides output such as

```
az webapp list-runtimes --os-type linux
[
  "DOTNETCORE:9.0",
  "DOTNETCORE:8.0",
  "DOTNETCORE:7.0",
  "DOTNETCORE:6.0",
  "NODE:20-lts",
  "NODE:18-lts",
  "NODE:16-lts",
  "PYTHON:3.12",
  "PYTHON:3.11",
  "PYTHON:3.10",
  "PYTHON:3.9",
  "PYTHON:3.8",
  "PHP:8.3",
  "PHP:8.2",
  "PHP:8.1",
  "PHP:8.0",
  "JAVA:21-java21",
  "JAVA:17-java17",
  "JAVA:11-java11",
  "JAVA:8-jre8",
  "JBOSSEAP:8-java17",
  "JBOSSEAP:8-java11",
  "JBOSSEAP:8-java17_byol",
  "JBOSSEAP:8-java11_byol",
  "JBOSSEAP:7-java17",
  "JBOSSEAP:7-java11",
  "JBOSSEAP:7-java8",
  "JBOSSEAP:7-java17_byol",
  "JBOSSEAP:7-java11_byol",
  "JBOSSEAP:7-java8_byol",
  "TOMCAT:10.1-java21",
  "TOMCAT:10.1-java17",
  "TOMCAT:10.1-java11",
  "TOMCAT:10.0-java17",
  "TOMCAT:10.0-java11",
  "TOMCAT:10.0-jre8",
  "TOMCAT:9.0-java21",
  "TOMCAT:9.0-java17",
  "TOMCAT:9.0-java11",
  "TOMCAT:9.0-jre8",
  "TOMCAT:8.5-java11",
  "TOMCAT:8.5-jre8"
]
```


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
