### PR TITLE
Expressroute port debug

### DIFF
--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -300,8 +300,6 @@ func resourceArmExpressRoutePortUpdate(d *pluginsdk.ResourceData, meta interface
 	locks.ByID(id.ID())
 	defer locks.UnlockByID(id.ID())
 
-	payload.Properties.Links = expandExpressRoutePortLinks(d.Get("link1").([]interface{}), d.Get("link2").([]interface{}))
-
 	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}

--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -272,12 +272,12 @@ func resourceArmExpressRoutePortUpdate(d *pluginsdk.ResourceData, meta interface
 
 	// Debug: Log the existing API model's identity before any changes
 	log.Printf("[DEBUG] Express Route Port %s - Existing API model identity: %+v", id, payload.Identity)
-	
+
 	// Debug: Check if existing identity is nil vs empty
 	if payload.Identity == nil {
 		log.Printf("[DEBUG] Express Route Port %s - Existing identity is NIL", id)
 	} else {
-		log.Printf("[DEBUG] Express Route Port %s - Existing identity is NOT nil: Type=%v, UserAssignedIdentities=%+v", 
+		log.Printf("[DEBUG] Express Route Port %s - Existing identity is NOT nil: Type=%v, UserAssignedIdentities=%+v",
 			id, payload.Identity.Type, payload.Identity.UserAssignedIdentities)
 	}
 
@@ -285,12 +285,12 @@ func resourceArmExpressRoutePortUpdate(d *pluginsdk.ResourceData, meta interface
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
-	
+
 	// Debug: Log the expanded identity from Terraform state
 	log.Printf("[DEBUG] Express Route Port %s - Expanded identity from TF state: %+v", id, expandedIdentity)
-	
+
 	payload.Identity = expandedIdentity
-	
+
 	// Debug: Log final payload identity after assignment
 	log.Printf("[DEBUG] Express Route Port %s - Final payload identity: %+v", id, payload.Identity)
 

--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -258,6 +258,9 @@ func resourceArmExpressRoutePortUpdate(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
+	// Debug: Log the full response from Azure ARM API
+	log.Printf("[DEBUG] Express Route Port %s - Full Azure ARM API response: %+v", id, existing)
+
 	if existing.Model == nil {
 		return fmt.Errorf("retrieving %s: `model` was nil", *id)
 	}
@@ -267,11 +270,29 @@ func resourceArmExpressRoutePortUpdate(d *pluginsdk.ResourceData, meta interface
 
 	payload := existing.Model
 
+	// Debug: Log the existing API model's identity before any changes
+	log.Printf("[DEBUG] Express Route Port %s - Existing API model identity: %+v", id, payload.Identity)
+	
+	// Debug: Check if existing identity is nil vs empty
+	if payload.Identity == nil {
+		log.Printf("[DEBUG] Express Route Port %s - Existing identity is NIL", id)
+	} else {
+		log.Printf("[DEBUG] Express Route Port %s - Existing identity is NOT nil: Type=%v, UserAssignedIdentities=%+v", 
+			id, payload.Identity.Type, payload.Identity.UserAssignedIdentities)
+	}
+
 	expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
+	
+	// Debug: Log the expanded identity from Terraform state
+	log.Printf("[DEBUG] Express Route Port %s - Expanded identity from TF state: %+v", id, expandedIdentity)
+	
 	payload.Identity = expandedIdentity
+	
+	// Debug: Log final payload identity after assignment
+	log.Printf("[DEBUG] Express Route Port %s - Final payload identity: %+v", id, payload.Identity)
 
 	if d.HasChange("billing_type") {
 		if v, ok := d.GetOk("billing_type"); ok {
@@ -292,6 +313,10 @@ func resourceArmExpressRoutePortUpdate(d *pluginsdk.ResourceData, meta interface
 	defer locks.UnlockByID(id.ID())
 
 	payload.Properties.Links = expandExpressRoutePortLinks(d.Get("link1").([]interface{}), d.Get("link2").([]interface{}))
+
+	// Debug: Log the complete payload being sent to Azure ARM API
+	log.Printf("[DEBUG] Express Route Port %s - Complete payload being sent to ARM API: %+v", id, *payload)
+	log.Printf("[DEBUG] Express Route Port %s - Payload identity being sent to ARM API: %+v", id, payload.Identity)
 
 	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)

--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -281,18 +281,20 @@ func resourceArmExpressRoutePortUpdate(d *pluginsdk.ResourceData, meta interface
 			id, payload.Identity.Type, payload.Identity.IdentityIds)
 	}
 
-	expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
-	if err != nil {
-		return fmt.Errorf("expanding `identity`: %+v", err)
+	if d.HasChange("identity") {
+		expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
+		}
+
+		// Debug: Log the expanded identity from Terraform state
+		log.Printf("[DEBUG] Express Route Port %s - Expanded identity from TF state: %+v", id, expandedIdentity)
+
+		payload.Identity = expandedIdentity
+
+		// Debug: Log final payload identity after assignment
+		log.Printf("[DEBUG] Express Route Port %s - Final payload identity: %+v", id, payload.Identity)
 	}
-
-	// Debug: Log the expanded identity from Terraform state
-	log.Printf("[DEBUG] Express Route Port %s - Expanded identity from TF state: %+v", id, expandedIdentity)
-
-	payload.Identity = expandedIdentity
-
-	// Debug: Log final payload identity after assignment
-	log.Printf("[DEBUG] Express Route Port %s - Final payload identity: %+v", id, payload.Identity)
 
 	if d.HasChange("billing_type") {
 		if v, ok := d.GetOk("billing_type"); ok {

--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -277,8 +277,8 @@ func resourceArmExpressRoutePortUpdate(d *pluginsdk.ResourceData, meta interface
 	if payload.Identity == nil {
 		log.Printf("[DEBUG] Express Route Port %s - Existing identity is NIL", id)
 	} else {
-		log.Printf("[DEBUG] Express Route Port %s - Existing identity is NOT nil: Type=%v, UserAssignedIdentities=%+v",
-			id, payload.Identity.Type, payload.Identity.UserAssignedIdentities)
+		log.Printf("[DEBUG] Express Route Port %s - Existing identity is NOT nil: Type=%v, IdentityIds=%+v",
+			id, payload.Identity.Type, payload.Identity.IdentityIds)
 	}
 
 	expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))

--- a/internal/services/network/express_route_port_resource_test.go
+++ b/internal/services/network/express_route_port_resource_test.go
@@ -362,7 +362,7 @@ resource "azurerm_express_route_port" "test" {
   link1 {
     admin_enabled = false
   }
-  
+
   link2 {
     admin_enabled = false
   }

--- a/internal/services/network/express_route_port_resource_test.go
+++ b/internal/services/network/express_route_port_resource_test.go
@@ -94,17 +94,10 @@ func TestAccExpressRoutePort_userAssignedIdentity(t *testing.T) {
 			Config: r.userAssignedIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("UserAssigned"),
+				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccExpressRoutePort_userAssignedIdentityTagUpdate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_express_route_port", "test")
-	r := ExpressRoutePortResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.userAssignedIdentityWithTags(data, "tag1"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -142,6 +135,31 @@ func TestAccExpressRoutePort_linkCipher(t *testing.T) {
 	})
 }
 
+func TestAccExpressRoutePort_identityRemoval(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_express_route_port", "test")
+	r := ExpressRoutePortResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.linkCipher(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("UserAssigned"),
+				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
+				check.That(data.ResourceName).Key("link1.0.macsec_cipher").HasValue("GcmAesXpn256"),
+			),
+		},
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r ExpressRoutePortResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	client := clients.Network.ExpressRoutePorts
 
@@ -164,10 +182,10 @@ func (r ExpressRoutePortResource) basic(data acceptance.TestData) string {
 %s
 
 resource "azurerm_express_route_port" "test" {
-  name                = "acctestERP-%d"
+  name                = "acctestERP-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  peering_location    = "Equinix-London-LDS"
+  peering_location    = "Airtel-Chennai2-CLS"
   bandwidth_in_gbps   = 10
   encapsulation       = "Dot1Q"
   billing_type        = "MeteredData"
@@ -175,7 +193,7 @@ resource "azurerm_express_route_port" "test" {
     ENV = "Test"
   }
 }
-`, template, data.RandomInteger)
+`, template, data.RandomIntOfLength(8))
 }
 
 func (r ExpressRoutePortResource) adminState(data acceptance.TestData) string {
@@ -228,7 +246,7 @@ resource "azurerm_express_route_port" "test" {
   name                = "acctestERP-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  peering_location    = "Equinix-Hong-Kong-HK1"
+  peering_location    = "Airtel-Chennai2-CLS"
   bandwidth_in_gbps   = 10
   encapsulation       = "Dot1Q"
   identity {
@@ -303,7 +321,7 @@ resource "azurerm_express_route_port" "test" {
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
   link1 {
-    macsec_cipher                 = "GcmAes256"
+    macsec_cipher                 = "GcmAesXpn256"
     macsec_ckn_keyvault_secret_id = azurerm_key_vault_secret.ckn.id
     macsec_cak_keyvault_secret_id = azurerm_key_vault_secret.cak.id
     macsec_sci_enabled            = true
@@ -339,6 +357,14 @@ resource "azurerm_express_route_port" "test" {
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  link1 {
+    admin_enabled = false
+  }
+  
+  link2 {
+    admin_enabled = false
   }
 
   tags = {

--- a/website/docs/r/express_route_port.html.markdown
+++ b/website/docs/r/express_route_port.html.markdown
@@ -70,7 +70,7 @@ A `link` block supports the following:
 
 * `admin_enabled` - (Optional) Whether enable administration state on the Express Route Port Link? Defaults to `false`.
   
-* `macsec_cipher` - (Optional) The MACSec cipher used for this Express Route Port Link. Possible values are `GcmAes128` and `GcmAes256`. Defaults to `GcmAes128`.
+* `macsec_cipher` - (Optional) The MACSec cipher used for this Express Route Port Link. Possible values are `GcmAes128`, `GcmAes256`, `GcmAesXpn128` and `GcmAesXpn256`. Defaults to `GcmAes128`.
 
 * `macsec_ckn_keyvault_secret_id` - (Optional) The ID of the Key Vault Secret that contains the MACSec CKN key for this Express Route Port Link.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
